### PR TITLE
style: refresh portal with ember palette and nav icon swap

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1,185 +1,219 @@
-/*
- * custom.css
- * Progressive enhancement stylesheet for the NetSapiens Manager Portal.
- */
-
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+/* custom.css - Aurora theme overhaul for NetSapiens Manager Portal */
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap");
 
 :root {
-  /* Color tokens */
-  --ns-color-bg: #f5f7fb;
-  --ns-color-surface: #ffffff;
-  --ns-color-surface-muted: #eef1f9;
-  --ns-color-surface-alt: #f9fbff;
-  --ns-color-border: rgba(24, 36, 64, 0.12);
-  --ns-color-border-strong: rgba(24, 36, 64, 0.2);
-  --ns-color-divider: rgba(24, 36, 64, 0.08);
-  --ns-color-text: #1e2433;
-  --ns-color-text-muted: #58607a;
-  --ns-color-text-inverse: #ffffff;
-  --ns-color-accent: #4254ff;
-  --ns-color-accent-soft: rgba(66, 84, 255, 0.14);
-  --ns-color-accent-strong: #2830b8;
-  --ns-color-success: #1f9d71;
-  --ns-color-danger: #d64545;
-  --ns-color-warning: #f4a640;
-  --ns-color-info: #3680ff;
-  --ns-color-focus: rgba(66, 84, 255, 0.45);
-  --ns-color-focus-strong: rgba(66, 84, 255, 0.75);
-  --ns-color-shadow: rgba(26, 39, 86, 0.16);
-  --ns-color-shadow-strong: rgba(26, 39, 86, 0.22);
-
-  /* Typography */
-  --ns-font-sans: "Inter", "Inter var", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  --ns-font-size-base: 15px;
-  --ns-font-size-sm: 13px;
-  --ns-font-size-lg: 17px;
-  --ns-line-height: 1.5;
-
-  /* Spacing */
-  --ns-space-2: 0.25rem;
-  --ns-space-3: 0.375rem;
-  --ns-space-4: 0.5rem;
-  --ns-space-6: 0.75rem;
-  --ns-space-8: 1rem;
-  --ns-space-10: 1.25rem;
-  --ns-space-12: 1.5rem;
-  --ns-space-16: 2rem;
-  --ns-space-20: 2.5rem;
-
-  /* Radii */
-  --ns-radius-sm: 6px;
-  --ns-radius-md: 12px;
-  --ns-radius-lg: 18px;
-  --ns-radius-pill: 999px;
-
-  /* Shadows */
-  --ns-shadow-card: 0 14px 36px -18px var(--ns-color-shadow);
-  --ns-shadow-card-strong: 0 30px 56px -32px var(--ns-color-shadow-strong);
-
-  /* Motion */
-  --ns-duration-fast: 120ms;
-  --ns-duration-base: 200ms;
-  --ns-duration-slow: 320ms;
-  --ns-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --aurora-bg: #fff4eb;
+  --aurora-bg-alt: #fff8f1;
+  --aurora-surface: #ffffff;
+  --aurora-surface-muted: rgba(255, 250, 245, 0.72);
+  --aurora-surface-glass: rgba(255, 245, 235, 0.65);
+  --aurora-border: rgba(128, 76, 35, 0.14);
+  --aurora-border-strong: rgba(128, 76, 35, 0.24);
+  --aurora-divider: rgba(142, 88, 46, 0.16);
+  --aurora-text: #2b1d13;
+  --aurora-text-soft: rgba(43, 29, 19, 0.78);
+  --aurora-text-subtle: rgba(43, 29, 19, 0.56);
+  --aurora-text-inverse: #ffffff;
+  --aurora-accent: #ff7a18;
+  --aurora-accent-strong: #ff5f0f;
+  --aurora-accent-soft: rgba(255, 122, 24, 0.22);
+  --aurora-success: #1c9c77;
+  --aurora-warning: #f59f22;
+  --aurora-danger: #f05a4a;
+  --aurora-info: #f6804c;
+  --aurora-focus: rgba(255, 122, 24, 0.45);
+  --aurora-shadow: rgba(112, 60, 28, 0.16);
+  --aurora-shadow-strong: rgba(112, 60, 28, 0.26);
+  --aurora-radius-xs: 6px;
+  --aurora-radius-sm: 12px;
+  --aurora-radius-md: 18px;
+  --aurora-radius-lg: 28px;
+  --aurora-radius-pill: 999px;
+  --aurora-font-sans: "Manrope", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --aurora-text-base: 16px;
+  --aurora-text-sm: 13px;
+  --aurora-text-xs: 12px;
+  --aurora-text-lg: 20px;
+  --aurora-line-height: 1.58;
+  --aurora-space-2: 0.25rem;
+  --aurora-space-3: 0.375rem;
+  --aurora-space-4: 0.5rem;
+  --aurora-space-5: 0.625rem;
+  --aurora-space-6: 0.75rem;
+  --aurora-space-8: 1rem;
+  --aurora-space-10: 1.25rem;
+  --aurora-space-12: 1.5rem;
+  --aurora-space-14: 1.75rem;
+  --aurora-space-16: 2rem;
+  --aurora-space-18: 2.25rem;
+  --aurora-space-20: 2.5rem;
+  --aurora-space-24: 3rem;
+  --aurora-space-28: 3.5rem;
+  --aurora-space-32: 4rem;
+  --aurora-duration-fast: 130ms;
+  --aurora-duration: 240ms;
+  --aurora-ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --ns-color-bg: #10131f;
-    --ns-color-surface: #171b2b;
-    --ns-color-surface-muted: #1f2437;
-    --ns-color-surface-alt: #22283d;
-    --ns-color-border: rgba(210, 220, 255, 0.12);
-    --ns-color-border-strong: rgba(210, 220, 255, 0.24);
-    --ns-color-divider: rgba(210, 220, 255, 0.1);
-    --ns-color-text: #f5f7ff;
-    --ns-color-text-muted: rgba(229, 233, 255, 0.72);
-    --ns-color-text-inverse: #0c0f1a;
-    --ns-color-accent: #7b91ff;
-    --ns-color-accent-soft: rgba(123, 145, 255, 0.16);
-    --ns-color-accent-strong: #9aa8ff;
-    --ns-color-success: #4fd8a4;
-    --ns-color-danger: #ff7a7a;
-    --ns-color-warning: #ffc76a;
-    --ns-color-info: #6a9dff;
-    --ns-color-focus: rgba(123, 145, 255, 0.6);
-    --ns-color-focus-strong: rgba(123, 145, 255, 0.85);
-    --ns-color-shadow: rgba(6, 9, 20, 0.6);
-    --ns-color-shadow-strong: rgba(6, 9, 20, 0.72);
-    --ns-shadow-card: 0 18px 44px -28px rgba(0, 0, 0, 0.9);
-    --ns-shadow-card-strong: 0 40px 80px -40px rgba(0, 0, 0, 0.9);
+    --aurora-bg: #1a120a;
+    --aurora-bg-alt: #21170d;
+    --aurora-surface: rgba(38, 26, 18, 0.96);
+    --aurora-surface-muted: rgba(48, 32, 22, 0.82);
+    --aurora-surface-glass: rgba(56, 36, 24, 0.62);
+    --aurora-border: rgba(255, 188, 120, 0.26);
+    --aurora-border-strong: rgba(255, 188, 120, 0.34);
+    --aurora-divider: rgba(255, 188, 120, 0.2);
+    --aurora-text: #fff4eb;
+    --aurora-text-soft: rgba(255, 228, 206, 0.8);
+    --aurora-text-subtle: rgba(255, 228, 206, 0.58);
+    --aurora-text-inverse: #1a120a;
+    --aurora-shadow: rgba(10, 6, 2, 0.7);
+    --aurora-shadow-strong: rgba(10, 6, 2, 0.82);
   }
 }
 
-/* Base styles */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 html,
 body {
-  font-family: var(--ns-font-sans);
-  font-size: var(--ns-font-size-base);
-  line-height: var(--ns-line-height);
-  background-color: var(--ns-color-bg) !important;
-  color: var(--ns-color-text);
-  text-rendering: optimizeLegibility;
+  min-height: 100%;
+  font-family: var(--aurora-font-sans);
+  font-size: var(--aurora-text-base);
+  line-height: var(--aurora-line-height);
+  background: var(--aurora-bg);
+  color: var(--aurora-text);
+  scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
 }
 
 body {
-  min-height: 100vh;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  background-image: radial-gradient(120% 120% at 15% 10%, rgba(255, 122, 24, 0.2) 0%, rgba(255, 122, 24, 0) 60%),
+    radial-gradient(150% 150% at 82% 6%, rgba(255, 190, 92, 0.22) 0%, rgba(255, 190, 92, 0) 68%),
+    radial-gradient(180% 180% at 50% 88%, rgba(255, 125, 69, 0.2) 0%, rgba(255, 125, 69, 0) 74%);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  z-index: -1;
+  pointer-events: none;
+  filter: blur(80px);
+  opacity: 0.7;
+}
+
+body::before {
+  width: 32vw;
+  height: 32vw;
+  left: -8vw;
+  top: 12vh;
+  background: linear-gradient(130deg, rgba(255, 122, 24, 0.4), rgba(255, 190, 92, 0.25));
+  animation: aurora-pulse 14s infinite alternate ease-in-out;
+}
+
+body::after {
+  width: 42vw;
+  height: 42vw;
+  right: -18vw;
+  top: 40vh;
+  background: linear-gradient(160deg, rgba(255, 125, 69, 0.38), rgba(255, 214, 150, 0.28));
+  animation: aurora-pulse 18s infinite alternate-reverse ease-in-out;
+}
+
+@keyframes aurora-pulse {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(4%, -2%, 0) scale(1.04);
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0 0 var(--aurora-space-6);
   font-weight: 600;
-  color: var(--ns-color-text);
-  letter-spacing: -0.012em;
+  letter-spacing: -0.02em;
+  color: var(--aurora-text);
 }
 
-p,
-li,
-dl,
-dt,
-dd {
-  color: var(--ns-color-text-muted);
+p {
+  margin: 0 0 var(--aurora-space-6);
+  color: var(--aurora-text-soft);
 }
 
-/* Header / navigation */
+a {
+  color: var(--aurora-accent);
+  text-decoration: none;
+  transition: color var(--aurora-duration) var(--aurora-ease);
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--aurora-accent-strong);
+}
+
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid var(--aurora-focus);
+  outline-offset: 3px;
+}
+
+/* Sticky glass header */
 .navigation-subbar,
 #ns-topbar,
 .header-bar,
-.navbar,
-.navbar.navbar-default,
-.navbar.navbar-inverse {
+.navbar {
   position: sticky;
   top: 0;
-  z-index: 1040;
+  inset-inline: 0;
+  z-index: 1035;
   display: flex;
   align-items: center;
-  gap: var(--ns-space-8);
-  padding: var(--ns-space-4) var(--ns-space-16);
-  background: linear-gradient(135deg, var(--ns-color-accent) 0%, var(--ns-color-accent-strong) 100%) !important;
-  border-bottom: 1px solid transparent !important;
-  box-shadow: none;
-  transition: box-shadow var(--ns-duration-base) var(--ns-ease), backdrop-filter var(--ns-duration-base) var(--ns-ease), padding var(--ns-duration-base) var(--ns-ease);
-  backdrop-filter: saturate(140%) blur(0px);
+  gap: var(--aurora-space-8);
+  padding: var(--aurora-space-4) var(--aurora-space-18);
+  background: linear-gradient(115deg, rgba(255, 122, 24, 0.92), rgba(255, 178, 72, 0.82));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(22px) saturate(160%);
+  box-shadow: 0 22px 48px -32px var(--aurora-shadow-strong);
+  transition: padding var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    backdrop-filter var(--aurora-duration-fast) var(--aurora-ease);
 }
 
 .navigation-subbar.is-scrolled,
 #ns-topbar.is-scrolled,
 .header-bar.is-scrolled,
 .navbar.is-scrolled {
-  box-shadow: 0 10px 32px -18px var(--ns-color-shadow-strong);
-  backdrop-filter: saturate(160%) blur(12px);
-  padding-block: var(--ns-space-3);
+  padding-block: var(--aurora-space-3);
+  box-shadow: 0 16px 32px -22px var(--aurora-shadow-strong);
 }
 
-.ns-modern-topbar-brand {
-  display: flex;
+.ns-brand {
+  display: inline-flex;
   align-items: center;
-  gap: var(--ns-space-4);
-  margin-right: var(--ns-space-12);
+  gap: var(--aurora-space-6);
+  margin-right: var(--aurora-space-16);
 }
 
-.ns-modern-logo {
-  width: 132px;
-  max-height: 36px;
+.ns-brand__logo {
   display: block;
-}
-
-@media (max-width: 768px) {
-  .ns-modern-logo {
-    width: 112px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .ns-modern-logo {
-    filter: brightness(1.08);
-  }
+  width: 146px;
+  max-height: 40px;
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.18));
 }
 
 .navigation-subbar .nav,
@@ -188,15 +222,11 @@ dd {
 .navbar .nav {
   display: flex;
   align-items: center;
-  gap: var(--ns-space-4);
+  gap: var(--aurora-space-4);
   margin: 0;
-}
-
-.navigation-subbar .nav > li,
-#ns-topbar .nav > li,
-.header-bar .nav > li,
-.navbar .nav > li {
+  padding: 0;
   list-style: none;
+  flex-wrap: wrap;
 }
 
 .navigation-subbar .nav > li > a,
@@ -204,345 +234,625 @@ dd {
 #ns-topbar .nav > li > a,
 #ns-topbar .nav > li > button,
 .header-bar .nav > li > a,
-.navbar .nav > li > a,
-.navigation-subbar .btn,
-.navbar .btn,
-.header-bar .btn {
-  position: relative;
+.navbar .nav > li > a {
   display: inline-flex !important;
   align-items: center;
-  gap: var(--ns-space-3);
-  padding: var(--ns-space-3) var(--ns-space-8) !important;
-  border-radius: var(--ns-radius-pill) !important;
+  gap: var(--aurora-space-3);
+  padding: var(--aurora-space-4) var(--aurora-space-10) !important;
+  border-radius: var(--aurora-radius-pill) !important;
   border: 1px solid transparent !important;
-  background: rgba(255, 255, 255, 0.14) !important;
-  color: var(--ns-color-text-inverse) !important;
-  font-weight: 500;
+  background: rgba(255, 255, 255, 0.18) !important;
+  color: var(--aurora-text-inverse) !important;
+  font-weight: 600;
   letter-spacing: 0.01em;
-  transition: background var(--ns-duration-base) var(--ns-ease), color var(--ns-duration-base) var(--ns-ease), transform var(--ns-duration-base) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    background var(--aurora-duration-fast) var(--aurora-ease);
 }
 
 .navigation-subbar .nav > li > a:hover,
-.navigation-subbar .nav > li > button:hover,
 .navigation-subbar .nav > li > a:focus-visible,
+.navigation-subbar .nav > li > button:hover,
 .navigation-subbar .nav > li > button:focus-visible,
+.header-bar .nav > li > a:hover,
+.header-bar .nav > li > a:focus-visible,
 .navbar .nav > li > a:hover,
 .navbar .nav > li > a:focus-visible {
-  background: rgba(255, 255, 255, 0.24) !important;
-  color: var(--ns-color-text-inverse) !important;
-  box-shadow: 0 8px 24px -16px rgba(0, 0, 0, 0.6);
   transform: translateY(-1px);
+  box-shadow: 0 18px 38px -24px rgba(0, 0, 0, 0.6);
+  background: rgba(255, 255, 255, 0.28) !important;
 }
 
-.navigation-subbar .nav > li.is-active > a,
 .navigation-subbar .nav > li.active > a,
+.header-bar .nav > li.active > a,
 .navbar .nav > li.active > a {
-  background: rgba(255, 255, 255, 0.28) !important;
-  color: var(--ns-color-text-inverse) !important;
+  background: rgba(255, 255, 255, 0.35) !important;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
 }
 
-.navigation-subbar .nav > li > a .badge {
-  background: var(--ns-color-accent-strong);
-  border-radius: var(--ns-radius-pill);
-  padding: 0 var(--ns-space-3);
-  font-size: var(--ns-font-size-sm);
+.navigation-subbar .nav-bg-image,
+#ns-topbar .nav-bg-image,
+.header-bar .nav-bg-image,
+.navbar .nav-bg-image {
+  display: none !important;
 }
 
-.ns-modern-header-actions {
+.ns-header-actions {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: var(--ns-space-4);
+  gap: var(--aurora-space-4);
 }
 
-.ns-modern-header-button {
+.ns-header-button {
   display: inline-flex;
   align-items: center;
-  gap: var(--ns-space-3);
-  padding: var(--ns-space-3) var(--ns-space-8);
-  border-radius: var(--ns-radius-pill);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  background: rgba(255, 255, 255, 0.18);
-  color: var(--ns-color-text-inverse);
+  gap: var(--aurora-space-3);
+  padding: var(--aurora-space-4) var(--aurora-space-10);
+  border-radius: var(--aurora-radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--aurora-text-inverse);
   font-weight: 600;
   cursor: pointer;
-  transition: transform var(--ns-duration-fast) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease), background var(--ns-duration-base) var(--ns-ease);
+  backdrop-filter: blur(12px);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    background var(--aurora-duration-fast) var(--aurora-ease);
 }
 
-.ns-modern-header-button:hover,
-.ns-modern-header-button:focus-visible {
-  background: rgba(255, 255, 255, 0.26);
-  box-shadow: 0 10px 28px -18px rgba(0, 0, 0, 0.6);
+.ns-header-button:hover,
+.ns-header-button:focus-visible {
   transform: translateY(-1px);
+  box-shadow: 0 20px 38px -24px rgba(0, 0, 0, 0.6);
+  background: rgba(255, 255, 255, 0.32);
 }
 
-/* Icon system */
-.ns-icon {
-  width: 24px;
-  height: 24px;
-  fill: currentColor;
-  flex-shrink: 0;
+.panel-heading .ns-header-button,
+.ns-surface .panel-heading .ns-header-button {
+  border-color: var(--aurora-border);
+  background: var(--aurora-surface);
+  color: var(--aurora-text);
+  box-shadow: none;
 }
 
-.ns-16 { width: 16px; height: 16px; }
-.ns-20 { width: 20px; height: 20px; }
-.ns-24 { width: 24px; height: 24px; }
+.panel-heading .ns-header-button:hover,
+.panel-heading .ns-header-button:focus-visible,
+.ns-surface .panel-heading .ns-header-button:hover,
+.ns-surface .panel-heading .ns-header-button:focus-visible {
+  background: var(--aurora-bg-alt);
+  box-shadow: 0 16px 32px -24px var(--aurora-shadow);
+}
 
-.ns-icon.muted { color: var(--ns-color-text-muted); }
-.ns-icon.success { color: var(--ns-color-success); }
-.ns-icon.warning { color: var(--ns-color-warning); }
-.ns-icon.danger { color: var(--ns-color-danger); }
-.ns-icon.info { color: var(--ns-color-info); }
+.ns-header-time {
+  font-size: var(--aurora-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.72);
+}
 
-/* Focus states */
-a:focus-visible,
-button:focus-visible,
-[role="button"]:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: 3px solid var(--ns-color-focus);
-  outline-offset: 3px;
+/* Shell layout */
+.content-wrapper,
+.page-content,
+main,
+#content,
+.container-fluid {
+  width: min(1200px, 92vw);
+  margin: var(--aurora-space-18) auto var(--aurora-space-24);
+  display: flex;
+  flex-direction: column;
+  gap: var(--aurora-space-16);
+}
+
+.ns-shell {
+  display: grid;
+  gap: var(--aurora-space-16);
+}
+
+/* Hero */
+.ns-hero {
+  position: relative;
+  overflow: hidden;
+  padding: var(--aurora-space-20) var(--aurora-space-18);
+  border-radius: var(--aurora-radius-lg);
+  border: 1px solid var(--aurora-border);
+  background: linear-gradient(135deg, rgba(255, 122, 24, 0.92), rgba(255, 168, 76, 0.88));
+  color: var(--aurora-text-inverse);
+  box-shadow: 0 40px 80px -48px var(--aurora-shadow-strong);
+}
+
+.ns-hero::after {
+  content: "";
+  position: absolute;
+  inset: 12% 4% auto auto;
+  width: clamp(120px, 18vw, 220px);
+  aspect-ratio: 1;
+  border-radius: 40%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 65%);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.ns-hero__eyebrow {
+  font-size: var(--aurora-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  opacity: 0.7;
+  margin-bottom: var(--aurora-space-6);
+}
+
+.ns-hero__title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin-bottom: var(--aurora-space-6);
+}
+
+.ns-hero__subtitle {
+  font-size: 1.05rem;
+  max-width: 42ch;
+  opacity: 0.86;
+}
+
+.ns-hero__meta {
+  margin-top: var(--aurora-space-12);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--aurora-space-4);
+  padding: var(--aurora-space-4) var(--aurora-space-10);
+  border-radius: var(--aurora-radius-pill);
+  background: rgba(255, 255, 255, 0.2);
+  font-size: var(--aurora-text-xs);
+  letter-spacing: 0.08em;
 }
 
 /* Quick actions */
 .ns-quick-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--ns-space-6);
-  margin-bottom: var(--ns-space-12);
+  gap: var(--aurora-space-6);
 }
 
 .ns-quick-actions__btn {
   display: inline-flex;
   align-items: center;
-  gap: var(--ns-space-3);
-  padding: var(--ns-space-4) var(--ns-space-10);
-  border-radius: var(--ns-radius-pill);
-  border: 1px solid var(--ns-color-border);
-  background: var(--ns-color-surface);
-  color: var(--ns-color-text);
+  justify-content: center;
+  gap: var(--aurora-space-3);
+  padding: var(--aurora-space-6) var(--aurora-space-12);
+  border-radius: var(--aurora-radius-pill);
+  border: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  color: var(--aurora-text);
   font-weight: 600;
-  box-shadow: var(--ns-shadow-card);
-  transition: transform var(--ns-duration-fast) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease), border-color var(--ns-duration-base) var(--ns-ease);
+  box-shadow: 0 28px 56px -40px var(--aurora-shadow);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    border-color var(--aurora-duration-fast) var(--aurora-ease);
 }
 
 .ns-quick-actions__btn:hover,
 .ns-quick-actions__btn:focus-visible {
-  transform: translateY(-2px);
-  border-color: var(--ns-color-accent);
-  box-shadow: var(--ns-shadow-card-strong);
+  transform: translateY(-3px);
+  border-color: var(--aurora-accent);
+  box-shadow: 0 38px 74px -48px var(--aurora-shadow-strong);
 }
 
-.ns-quick-actions__btn:active {
-  transform: translateY(0);
+/* Metrics */
+.ns-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--aurora-space-8);
 }
 
-/* Global search */
-.ns-global-search {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ns-space-3);
-  margin-bottom: var(--ns-space-10);
+.ns-metric {
+  position: relative;
+  padding: var(--aurora-space-14);
+  border-radius: var(--aurora-radius-md);
+  border: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  box-shadow: 0 28px 64px -46px var(--aurora-shadow);
+  overflow: hidden;
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease);
 }
 
-.ns-global-search label {
-  font-weight: 600;
-  color: var(--ns-color-text);
+.ns-metric:hover,
+.ns-metric:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 42px 82px -48px var(--aurora-shadow-strong);
 }
 
-.ns-global-search input[type="search"] {
-  padding: var(--ns-space-4) var(--ns-space-8);
-  border-radius: var(--ns-radius-pill);
-  border: 1px solid var(--ns-color-border);
-  background: var(--ns-color-surface);
-  color: var(--ns-color-text);
-  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
-  transition: border-color var(--ns-duration-base) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease);
+.ns-metric::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% -60% 40%;
+  width: 70%;
+  height: 140%;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 122, 24, 0.24), rgba(255, 122, 24, 0));
+  transform: rotate(-18deg);
 }
 
-.ns-global-search input[type="search"]:focus-visible {
-  border-color: var(--ns-color-accent);
-  box-shadow: 0 0 0 3px var(--ns-color-accent-soft);
+.ns-metric__label {
+  font-size: var(--aurora-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--aurora-text-subtle);
+  margin-bottom: var(--aurora-space-4);
 }
 
-/* Cards / panels */
-.ns-modern-card,
+.ns-metric__value {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--aurora-text);
+}
+
+.ns-metric__trend {
+  margin-top: var(--aurora-space-3);
+  font-size: var(--aurora-text-sm);
+  color: var(--aurora-success);
+}
+
+.ns-metric--warning .ns-metric__trend {
+  color: var(--aurora-warning);
+}
+
+.ns-metric--danger .ns-metric__trend {
+  color: var(--aurora-danger);
+}
+
+.ns-metric--success .ns-metric__trend {
+  color: var(--aurora-success);
+}
+
+/* Cards & panels */
 .panel,
+.card,
 .box,
 .tile,
 .dashboard-card,
-.portlet {
+.portlet,
+.ns-surface {
   position: relative;
-  border-radius: var(--ns-radius-md) !important;
-  background: var(--ns-color-surface) !important;
-  border: 1px solid var(--ns-color-border) !important;
-  box-shadow: var(--ns-shadow-card);
+  border-radius: var(--aurora-radius-md) !important;
+  border: 1px solid var(--aurora-border) !important;
+  background: var(--aurora-surface) !important;
+  box-shadow: 0 32px 70px -48px var(--aurora-shadow);
   overflow: hidden;
-  margin-bottom: var(--ns-space-12);
-  transition: transform var(--ns-duration-base) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    border-color var(--aurora-duration-fast) var(--aurora-ease);
 }
 
-.ns-modern-card:hover,
 .panel:hover,
+.card:hover,
 .box:hover,
 .tile:hover,
 .dashboard-card:hover,
-.portlet:hover {
+.portlet:hover,
+.ns-surface:hover {
   transform: translateY(-2px);
-  box-shadow: var(--ns-shadow-card-strong);
+  box-shadow: 0 46px 96px -62px var(--aurora-shadow-strong);
 }
 
 .panel-heading,
+.card-header,
 .box-header,
-.tile .tile-title,
 .dashboard-card .header,
-.portlet-title,
-.ns-modern-card__header {
+.portlet-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--ns-space-6);
-  padding: var(--ns-space-6) var(--ns-space-10);
-  border-bottom: 1px solid var(--ns-color-divider);
-  background: var(--ns-color-surface-muted);
-  color: var(--ns-color-text);
+  gap: var(--aurora-space-6);
+  padding: var(--aurora-space-10) var(--aurora-space-14);
+  border-bottom: 1px solid var(--aurora-divider);
+  background: var(--aurora-bg-alt);
   font-weight: 600;
-}
-
-.panel-heading .btn,
-.box-header .btn,
-.tile .tile-title .btn,
-.dashboard-card .header .btn {
-  border-radius: var(--ns-radius-pill);
-  padding-inline: var(--ns-space-6);
+  color: var(--aurora-text);
 }
 
 .panel-body,
+.card-body,
 .box-body,
-.tile .tile-body,
 .dashboard-card .content,
-.portlet-body,
-.ns-modern-card__body {
-  padding: var(--ns-space-10);
-  background: var(--ns-color-surface);
-  color: var(--ns-color-text);
+.portlet-body {
+  padding: var(--aurora-space-14);
+  color: var(--aurora-text-soft);
 }
 
 .panel-footer,
+.card-footer,
 .box-footer,
-.tile .tile-footer,
 .dashboard-card .footer,
 .portlet-footer {
-  padding: var(--ns-space-6) var(--ns-space-10);
-  border-top: 1px solid var(--ns-color-divider);
-  background: var(--ns-color-surface-muted);
+  padding: var(--aurora-space-10) var(--aurora-space-14);
+  border-top: 1px solid var(--aurora-divider);
+  background: var(--aurora-bg-alt);
 }
 
-/* Tables */
-.table {
-  background: transparent;
-  border: 1px solid var(--ns-color-border);
-  border-radius: var(--ns-radius-md);
-  overflow: hidden;
+/* Tables transformed into call cards */
+#calls_table,
+#calls_table_meetings {
+  width: 100%;
+  border-collapse: collapse;
+  background: transparent !important;
+  color: var(--aurora-text);
 }
 
-.table thead th {
-  background: var(--ns-color-surface-muted);
-  color: var(--ns-color-text);
+#calls_table thead,
+#calls_table_meetings thead {
+  display: none;
+}
+
+#calls_table tbody,
+#calls_table_meetings tbody {
+  display: grid;
+  gap: var(--aurora-space-8);
+  padding: 0;
+  margin: 0;
+}
+
+#calls_table tbody tr,
+#calls_table_meetings tbody tr {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--aurora-space-6);
+  padding: var(--aurora-space-12) var(--aurora-space-14);
+  border-radius: var(--aurora-radius-md);
+  border: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  box-shadow: 0 30px 70px -56px var(--aurora-shadow);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    border-color var(--aurora-duration-fast) var(--aurora-ease);
+}
+
+#calls_table tbody tr:nth-child(even),
+#calls_table_meetings tbody tr:nth-child(even) {
+  background: linear-gradient(135deg, rgba(255, 122, 24, 0.08), rgba(255, 255, 255, 1));
+}
+
+#calls_table tbody tr:hover,
+#calls_table tbody tr:focus-visible,
+#calls_table tbody tr:focus-within,
+#calls_table_meetings tbody tr:hover,
+#calls_table_meetings tbody tr:focus-visible,
+#calls_table_meetings tbody tr:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 44px 94px -64px var(--aurora-shadow-strong);
+  border-color: var(--aurora-accent);
+}
+
+#calls_table tbody tr:focus-visible,
+#calls_table tbody tr:focus-within,
+#calls_table_meetings tbody tr:focus-visible,
+#calls_table_meetings tbody tr:focus-within {
+  outline: 3px solid var(--aurora-focus);
+  outline-offset: 3px;
+}
+
+#calls_table tbody td,
+#calls_table_meetings tbody td {
+  display: flex;
+  flex-direction: column;
+  gap: var(--aurora-space-2);
+  border: none !important;
+  padding: 0;
+  min-width: 0;
+  color: var(--aurora-text);
+}
+
+#calls_table tbody td:first-child,
+#calls_table_meetings tbody td:first-child {
   font-weight: 600;
-  border-bottom: 1px solid var(--ns-color-border);
+  font-size: 1.1rem;
 }
 
-.table td,
-.table th {
-  border-color: var(--ns-color-divider) !important;
-  padding: var(--ns-space-4) var(--ns-space-6);
-  vertical-align: middle;
+#calls_table tbody td::before,
+#calls_table_meetings tbody td::before {
+  content: attr(data-label);
+  font-size: var(--aurora-text-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--aurora-text-subtle);
 }
 
-.table-striped > tbody > tr:nth-of-type(odd) {
-  background: var(--ns-color-surface-alt);
+.ns-call-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--aurora-space-2);
+  padding: var(--aurora-space-2) var(--aurora-space-6);
+  border-radius: var(--aurora-radius-pill);
+  font-size: var(--aurora-text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--aurora-accent-soft);
+  color: var(--aurora-accent-strong);
 }
 
-@media (prefers-color-scheme: dark) {
-  .table-striped > tbody > tr:nth-of-type(odd) {
-    background: rgba(255, 255, 255, 0.04);
-  }
+/* Search bar */
+.ns-search {
+  display: flex;
+  flex-direction: column;
+  gap: var(--aurora-space-4);
 }
 
-.table-hover > tbody > tr:hover {
-  background: var(--ns-color-accent-soft);
+.ns-search label {
+  font-size: var(--aurora-text-xs);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--aurora-text-subtle);
 }
 
-.table-empty-state,
+.ns-search input[type="search"] {
+  width: min(360px, 100%);
+  padding: var(--aurora-space-6) var(--aurora-space-10);
+  border-radius: var(--aurora-radius-pill);
+  border: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  color: var(--aurora-text);
+  transition: border-color var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease);
+}
+
+.ns-search input[type="search"]::placeholder {
+  color: var(--aurora-text-subtle);
+}
+
+.ns-search input[type="search"]:focus-visible {
+  border-color: var(--aurora-accent);
+  box-shadow: 0 0 0 3px var(--aurora-accent-soft);
+}
+
 .ns-empty-state {
-  padding: var(--ns-space-12);
+  padding: var(--aurora-space-12);
+  border-radius: var(--aurora-radius-md);
+  background: var(--aurora-surface);
+  border: 1px dashed var(--aurora-border);
+  color: var(--aurora-text-subtle);
   text-align: center;
-  color: var(--ns-color-text-muted);
-  font-size: var(--ns-font-size-lg);
 }
 
-/* Graph containers */
-.chart,
-.graph,
-.canvas-wrapper {
-  background: var(--ns-color-surface);
-  border-radius: var(--ns-radius-md);
-  border: 1px solid var(--ns-color-border);
-  padding: var(--ns-space-8);
-  box-shadow: var(--ns-shadow-card);
+/* Buttons */
+button,
+input[type="button"],
+input[type="submit"],
+input[type="reset"],
+.button,
+.btn {
+  font-family: inherit;
+  font-weight: 600;
+  border-radius: var(--aurora-radius-pill);
+  border: 1px solid transparent;
+  padding: var(--aurora-space-4) var(--aurora-space-12);
+  background: var(--aurora-accent);
+  color: var(--aurora-text-inverse);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease),
+    background var(--aurora-duration-fast) var(--aurora-ease);
+}
+
+button:hover,
+button:focus-visible,
+input[type="button"]:hover,
+input[type="submit"]:hover,
+input[type="reset"]:hover,
+.button:hover,
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 38px -26px var(--aurora-shadow);
+  background: var(--aurora-accent-strong);
+}
+
+/* Forms */
+input,
+select,
+textarea {
+  border-radius: var(--aurora-radius-sm);
+  border: 1px solid var(--aurora-border);
+  padding: var(--aurora-space-4) var(--aurora-space-6);
+  background: var(--aurora-surface);
+  color: var(--aurora-text);
+  transition: border-color var(--aurora-duration-fast) var(--aurora-ease),
+    box-shadow var(--aurora-duration-fast) var(--aurora-ease);
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+  border-color: var(--aurora-accent);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--aurora-accent);
+  box-shadow: 0 0 0 3px var(--aurora-accent-soft);
 }
 
 /* Toasts */
 .ns-toast-stack {
   position: fixed;
-  top: var(--ns-space-16);
-  right: var(--ns-space-16);
+  top: var(--aurora-space-20);
+  right: var(--aurora-space-20);
   display: flex;
   flex-direction: column;
-  gap: var(--ns-space-4);
+  gap: var(--aurora-space-6);
   z-index: 2000;
 }
 
 .ns-toast {
-  min-width: 220px;
-  max-width: 320px;
-  padding: var(--ns-space-6) var(--ns-space-10);
-  border-radius: var(--ns-radius-md);
-  background: var(--ns-color-surface);
-  border: 1px solid var(--ns-color-border);
-  box-shadow: var(--ns-shadow-card);
-  color: var(--ns-color-text);
-  font-weight: 500;
-  transition: opacity var(--ns-duration-base) var(--ns-ease), transform var(--ns-duration-base) var(--ns-ease);
-  opacity: 1;
+  min-width: 260px;
+  max-width: 340px;
+  padding: var(--aurora-space-8) var(--aurora-space-12);
+  border-radius: var(--aurora-radius-md);
+  border: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  color: var(--aurora-text);
+  display: flex;
+  align-items: center;
+  gap: var(--aurora-space-6);
+  box-shadow: 0 28px 70px -48px var(--aurora-shadow);
+  transition: transform var(--aurora-duration-fast) var(--aurora-ease),
+    opacity var(--aurora-duration-fast) var(--aurora-ease);
 }
 
 .ns-toast[data-state="enter"] {
-  transform: translateY(-8px);
+  transform: translateY(-6px);
 }
 
 .ns-toast[data-state="leave"] {
   opacity: 0;
-  transform: translateY(-4px);
+  transform: translateY(-2px);
+}
+
+.ns-toast__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--aurora-accent-soft);
+  color: var(--aurora-accent-strong);
+}
+
+.ns-toast__message {
+  flex: 1;
+  font-weight: 600;
+}
+
+.ns-toast__close {
+  border: none;
+  background: none;
+  color: var(--aurora-text-subtle);
+  border-radius: var(--aurora-radius-pill);
+  padding: var(--aurora-space-2) var(--aurora-space-3);
+}
+
+.ns-toast__close:hover,
+.ns-toast__close:focus-visible {
+  color: var(--aurora-text);
+  background: var(--aurora-bg-alt);
 }
 
 /* Drawer */
-body.ns-modern-drawer-open {
+body.ns-drawer-open {
   overflow: hidden;
 }
 
 .ns-drawer-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(8, 15, 30, 0.45);
-  backdrop-filter: blur(2px);
+  background: rgba(10, 12, 24, 0.5);
+  backdrop-filter: blur(4px);
   opacity: 0;
   pointer-events: none;
-  transition: opacity var(--ns-duration-base) var(--ns-ease);
-  z-index: 1990;
+  transition: opacity var(--aurora-duration) var(--aurora-ease);
+  z-index: 1995;
 }
 
 .ns-drawer-overlay.is-visible {
@@ -554,15 +864,15 @@ body.ns-modern-drawer-open {
   position: fixed;
   top: 0;
   right: 0;
-  width: min(360px, 90vw);
+  width: min(400px, 94vw);
   height: 100vh;
-  background: var(--ns-color-surface);
-  border-left: 1px solid var(--ns-color-border);
-  box-shadow: -12px 0 32px -24px var(--ns-color-shadow-strong);
-  transform: translateX(100%);
-  transition: transform var(--ns-duration-base) var(--ns-ease);
   display: flex;
   flex-direction: column;
+  border-left: 1px solid var(--aurora-border);
+  background: var(--aurora-surface);
+  box-shadow: -36px 0 80px -48px var(--aurora-shadow-strong);
+  transform: translateX(110%);
+  transition: transform var(--aurora-duration) var(--aurora-ease);
   z-index: 2005;
 }
 
@@ -571,41 +881,70 @@ body.ns-modern-drawer-open {
 }
 
 .ns-drawer__header {
-  padding: var(--ns-space-10);
-  border-bottom: 1px solid var(--ns-color-divider);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--ns-space-4);
+  gap: var(--aurora-space-4);
+  padding: var(--aurora-space-14);
+  border-bottom: 1px solid var(--aurora-divider);
 }
 
 .ns-drawer__title {
-  font-weight: 600;
-  font-size: var(--ns-font-size-lg);
-  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
 .ns-drawer__body {
-  padding: var(--ns-space-10);
+  padding: var(--aurora-space-14);
+  color: var(--aurora-text-soft);
   overflow-y: auto;
-  color: var(--ns-color-text-muted);
 }
 
 .ns-drawer__close {
   border: none;
-  background: transparent;
-  color: var(--ns-color-text-muted);
-  border-radius: var(--ns-radius-pill);
-  padding: var(--ns-space-3);
+  background: none;
+  color: var(--aurora-text-subtle);
+  border-radius: var(--aurora-radius-pill);
+  padding: var(--aurora-space-2) var(--aurora-space-3);
 }
 
 .ns-drawer__close:hover,
 .ns-drawer__close:focus-visible {
-  color: var(--ns-color-text);
-  background: var(--ns-color-surface-muted);
+  color: var(--aurora-text);
+  background: var(--aurora-bg-alt);
 }
 
-/* Utilities */
+/* Utility */
+.ns-icon {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.ns-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--aurora-space-6);
+}
+
+.ns-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--aurora-space-2);
+  padding: var(--aurora-space-2) var(--aurora-space-6);
+  border-radius: var(--aurora-radius-pill);
+  font-size: var(--aurora-text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--aurora-bg-alt);
+  color: var(--aurora-text-subtle);
+}
+
+.ns-text-subtle {
+  color: var(--aurora-text-subtle);
+}
+
 .visually-hidden {
   position: absolute !important;
   width: 1px !important;
@@ -618,147 +957,41 @@ body.ns-modern-drawer-open {
   border: 0 !important;
 }
 
-.ns-flex {
-  display: flex !important;
-}
-
-.ns-flex-between {
-  display: flex !important;
-  justify-content: space-between !important;
-  align-items: center !important;
-}
-
-.ns-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ns-space-6);
-}
-
-.ns-muted {
-  color: var(--ns-color-text-muted) !important;
-}
-
-.ns-pill {
-  border-radius: var(--ns-radius-pill) !important;
-}
-
-.ns-mb-0 { margin-bottom: 0 !important; }
-.ns-mb-4 { margin-bottom: var(--ns-space-4) !important; }
-.ns-mb-6 { margin-bottom: var(--ns-space-6) !important; }
-.ns-mb-8 { margin-bottom: var(--ns-space-8) !important; }
-.ns-mb-12 { margin-bottom: var(--ns-space-12) !important; }
-.ns-mt-12 { margin-top: var(--ns-space-12) !important; }
-.ns-pt-10 { padding-top: var(--ns-space-10) !important; }
-.ns-p-8 { padding: var(--ns-space-8) !important; }
-.ns-p-10 { padding: var(--ns-space-10) !important; }
-
-/* Forms */
-input,
-select,
-textarea {
-  border-radius: var(--ns-radius-sm);
-  border: 1px solid var(--ns-color-border);
-  transition: border-color var(--ns-duration-base) var(--ns-ease), box-shadow var(--ns-duration-base) var(--ns-ease);
-}
-
-input:hover,
-select:hover,
-textarea:hover {
-  border-color: var(--ns-color-accent);
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  border-color: var(--ns-color-accent);
-  box-shadow: 0 0 0 3px var(--ns-color-accent-soft);
-}
-
-/* Buttons */
-.btn,
-button,
-input[type="submit"] {
-  border-radius: var(--ns-radius-pill);
-  transition: transform var(--ns-duration-fast) var(--ns-ease), box-shadow var(--ns-duration-fast) var(--ns-ease);
-}
-
-.btn:hover,
-button:hover,
-input[type="submit"]:hover {
-  transform: translateY(-1px);
-}
-
-/* Micro interactions */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
-
-/* Responsive adjustments */
-@media (max-width: 1200px) {
+@media (max-width: 1024px) {
   .navigation-subbar,
   #ns-topbar,
+  .header-bar,
   .navbar {
     flex-wrap: wrap;
-    padding-inline: var(--ns-space-12);
+    padding-inline: var(--aurora-space-12);
   }
 
-  .ns-modern-header-actions {
+  .ns-header-actions {
     width: 100%;
     justify-content: flex-end;
   }
-}
 
-@media (max-width: 992px) {
-  .navigation-subbar .nav,
-  #ns-topbar .nav,
-  .navbar .nav {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .ns-quick-actions {
-    justify-content: center;
-  }
-
-  .panel,
-  .box,
-  .tile,
-  .dashboard-card,
-  .portlet {
-    margin-bottom: var(--ns-space-16);
+  .ns-hero {
+    padding: var(--aurora-space-18);
   }
 }
 
 @media (max-width: 768px) {
-  .navigation-subbar,
-  #ns-topbar,
-  .navbar {
-    padding-inline: var(--ns-space-8);
+  .content-wrapper,
+  .page-content,
+  main,
+  #content,
+  .container-fluid {
+    width: 92vw;
+    margin: var(--aurora-space-16) auto;
   }
 
-  .panel-heading,
-  .box-header,
-  .dashboard-card .header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .panel-body,
-  .box-body,
-  .dashboard-card .content {
-    padding: var(--ns-space-8) !important;
+  .ns-hero {
+    padding: var(--aurora-space-16);
   }
 
   .ns-quick-actions__btn {
-    flex: 1 1 calc(50% - var(--ns-space-6));
-    justify-content: center;
+    flex: 1 1 calc(50% - var(--aurora-space-6));
   }
 }
 
@@ -767,7 +1000,34 @@ input[type="submit"]:hover {
     flex: 1 1 100%;
   }
 
-  .ns-global-search input[type="search"] {
-    width: 100%;
+  .ns-toast-stack {
+    right: var(--aurora-space-12);
+    left: var(--aurora-space-12);
   }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.24);
+  border-radius: var(--aurora-radius-pill);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.36);
 }

--- a/custom.js
+++ b/custom.js
@@ -1,35 +1,28 @@
 (function (window, document) {
   "use strict";
 
-  var ns = window.__nsModern = window.__nsModern || {};
-  ns.active = true;
-  if (!Array.isArray(ns.log)) {
-    ns.log = [];
-  }
+  var SPRITE_ID = "aurora-sprite";
+  var LOGO_LIGHT = "https://assets.example.com/net-aurora/logo-light.svg";
+  var LOGO_DARK = "https://assets.example.com/net-aurora/logo-dark.svg";
+  var TOAST_DURATION = 4200;
 
-  var LOGO_LIGHT_URL = "https://examplecdn.com/brand/logo-light.svg";
-  var LOGO_DARK_URL = "https://examplecdn.com/brand/logo-dark.svg";
-  var SPRITE_ID = "ns-modern-sprite";
-  var TOAST_DURATION = 3600;
-  var REDUCED_MOTION = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-  function onReady(fn) {
+  function onReady(callback) {
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", fn, { once: true });
+      document.addEventListener("DOMContentLoaded", callback, { once: true });
     } else {
-      fn();
+      callback();
     }
   }
 
   function throttle(fn, wait) {
+    var timeout = null;
     var last = 0;
-    var timeout;
     return function () {
       var now = Date.now();
       var remaining = wait - (now - last);
       var context = this;
       var args = arguments;
-      if (remaining <= 0 || remaining > wait) {
+      if (remaining <= 0) {
         if (timeout) {
           clearTimeout(timeout);
           timeout = null;
@@ -50,29 +43,30 @@
     if (document.getElementById(SPRITE_ID)) {
       return;
     }
-
-    var wrapper = document.createElement("div");
-    wrapper.style.display = "none";
-    wrapper.setAttribute("aria-hidden", "true");
-    wrapper.innerHTML = [
-      '<svg xmlns="http://www.w3.org/2000/svg" style="display:none" id="' + SPRITE_ID + '">',
-      '<symbol id="ns-home" viewBox="0 0 24 24"><path d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-5v-5h-4v5H5a1 1 0 0 1-1-1z"></path></symbol>',
-      '<symbol id="ns-callcenter" viewBox="0 0 24 24"><path d="M6 6a6 6 0 0 1 12 0v3h1a2 2 0 0 1 2 2v3a5 5 0 0 1-5 5h-1v-2h1a3 3 0 0 0 3-3v-3h-1v1a2 2 0 0 1-2 2h-1v-8a4 4 0 0 0-8 0v8H9a2 2 0 0 1-2-2v-1H6v3a3 3 0 0 0 3 3h1v2H9a5 5 0 0 1-5-5v-3a2 2 0 0 1 2-2h1z"></path></symbol>',
-      '<symbol id="ns-users" viewBox="0 0 24 24"><path d="M8 12a4 4 0 1 1 4-4 4 4 0 0 1-4 4zm8 0a3.5 3.5 0 1 1 3.5-3.5A3.5 3.5 0 0 1 16 12zm-8 2c-3.31 0-6 2.24-6 5v1h12v-1c0-2.76-2.69-5-6-5zm8 .5a5.5 5.5 0 0 1 5.5 5.5v1H14v-1a5.5 5.5 0 0 1 2-4.22z"></path></symbol>',
-      '<symbol id="ns-conferences" viewBox="0 0 24 24"><path d="M5 5h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-4l-4 4v-4H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2zm1 3v6h12V8z"></path></symbol>',
-      '<symbol id="ns-autoattendants" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9 9 9 0 0 1 9-9zm0 2a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm-.75 3.5h1.5v3.19l2.76 1.59-.75 1.3L11.25 13z"></path></symbol>',
-      '<symbol id="ns-queues" viewBox="0 0 24 24"><path d="M4 5h16v3H4zm2 5h12v3H6zm2 5h8v3H8z"></path></symbol>',
-      '<symbol id="ns-timeframes" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9 9 9 0 0 1 9-9zm0 2a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm-.75 2.5h1.5v4.44l3 1.73-.75 1.3-3.75-2.17z"></path></symbol>',
-      '<symbol id="ns-moh" viewBox="0 0 24 24"><path d="M6 5h2l2 4 2-4h2l2 4 2-4h2l-3 7 3 7h-2l-2-4-2 4h-2l-2-4-2 4H6l3-7z"></path></symbol>',
-      '<symbol id="ns-routes" viewBox="0 0 24 24"><path d="M6 3a3 3 0 1 1-3 3 3 3 0 0 1 3-3zm12 8a3 3 0 1 1-3 3 3 3 0 0 1 3-3zM8.41 8.41 11 11h2l2 2-2 2h-2l-2.59 2.59L6 15l3-3-3-3z"></path></symbol>',
-      '<symbol id="ns-inventory" viewBox="0 0 24 24"><path d="M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14l-8-4-8 4z"></path></symbol>',
-      '<symbol id="ns-smartrouting" viewBox="0 0 24 24"><path d="M5 4h4l2 3h4l4 6-4 6h-4l-2-3H5l-4-6z"></path></symbol>',
-      '<symbol id="ns-analytics" viewBox="0 0 24 24"><path d="M4 5h3v14H4zm13 0h3v14h-3zM9 11h3v8H9zm5-4h3v12h-3z"></path></symbol>',
-      '<symbol id="ns-callhistory" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9H5a7 7 0 1 0 7-7 1 1 0 0 1 0-2zm-.75 4.5h1.5V12h3v1.5h-4.5z"></path></symbol>',
-      "</svg>"
+    var sprite = document.createElement("div");
+    sprite.style.display = "none";
+    sprite.setAttribute("aria-hidden", "true");
+    sprite.innerHTML = [
+      '<svg xmlns="http://www.w3.org/2000/svg" id="' + SPRITE_ID + '" style="display:none">',
+      '<symbol id="aurora-home" viewBox="0 0 24 24"><path d="M4 11.5 12 4l8 7.5V21a1 1 0 0 1-1 1h-5v-5h-4v5H5a1 1 0 0 1-1-1z"/></symbol>',
+      '<symbol id="aurora-users" viewBox="0 0 24 24"><path d="M8 12a4 4 0 1 1 4-4 4 4 0 0 1-4 4zm8 0a3.5 3.5 0 1 1 3.5-3.5A3.5 3.5 0 0 1 16 12zm-8 2c-3.31 0-6 2.24-6 5v1h12v-1c0-2.76-2.69-5-6-5zm8 .5a5.5 5.5 0 0 1 5.5 5.5v1H14v-1a5.5 5.5 0 0 1 2-4.22z"/></symbol>',
+      '<symbol id="aurora-callcenter" viewBox="0 0 24 24"><path d="M6 6a6 6 0 0 1 12 0v3h1a2 2 0 0 1 2 2v3a5 5 0 0 1-5 5h-1v-2h1a3 3 0 0 0 3-3v-3h-1v1a2 2 0 0 1-2 2h-1v-8a4 4 0 0 0-8 0v8H9a2 2 0 0 1-2-2v-1H6v3a3 3 0 0 0 3 3h1v2H9a5 5 0 0 1-5-5v-3a2 2 0 0 1 2-2h1z"/></symbol>',
+      '<symbol id="aurora-conferences" viewBox="0 0 24 24"><path d="M5 5h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-4l-4 4v-4H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2zm1 3v6h12V8z"/></symbol>',
+      '<symbol id="aurora-autoattendants" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9 9 9 0 0 1 9-9zm0 2a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm-.75 3.5h1.5v3.19l2.76 1.59-.75 1.3L11.25 13z"/></symbol>',
+      '<symbol id="aurora-queues" viewBox="0 0 24 24"><path d="M4 5h16v3H4zm2 5h12v3H6zm2 5h8v3H8z"/></symbol>',
+      '<symbol id="aurora-timeframes" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9 9 9 0 0 1 9-9zm0 2a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm-.75 2.5h1.5v4.44l3 1.73-.75 1.3-3.75-2.17z"/></symbol>',
+      '<symbol id="aurora-moh" viewBox="0 0 24 24"><path d="M6 5h2l2 4 2-4h2l2 4 2-4h2l-3 7 3 7h-2l-2-4-2 4h-2l-2-4-2 4H6l3-7z"/></symbol>',
+      '<symbol id="aurora-routes" viewBox="0 0 24 24"><path d="M6 3a3 3 0 1 1-3 3 3 3 0 0 1 3-3zm12 8a3 3 0 1 1-3 3 3 3 0 0 1 3-3zM8.41 8.41 11 11h2l2 2-2 2h-2l-2.59 2.59L6 15l3-3-3-3z"/></symbol>',
+      '<symbol id="aurora-inventory" viewBox="0 0 24 24"><path d="M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14l-8-4-8 4z"/></symbol>',
+      '<symbol id="aurora-smartrouting" viewBox="0 0 24 24"><path d="M5 4h4l2 3h4l4 6-4 6h-4l-2-3H5l-4-6z"/></symbol>',
+      '<symbol id="aurora-analytics" viewBox="0 0 24 24"><path d="M4 5h3v14H4zm13 0h3v14h-3zM9 11h3v8H9zm5-4h3v12h-3z"/></symbol>',
+      '<symbol id="aurora-callhistory" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 1-9 9H5a7 7 0 1 0 7-7 1 1 0 0 1 0-2zm-.75 4.5h1.5V12h3v1.5h-4.5z"/></symbol>',
+      '<symbol id="aurora-plus" viewBox="0 0 24 24"><path d="M11 5h2v6h6v2h-6v6h-2v-6H5v-2h6z"/></symbol>',
+      '<symbol id="aurora-flash" viewBox="0 0 24 24"><path d="M7 2h10l-3.5 6H18l-8 14 2.5-9H7z"/></symbol>',
+      '<symbol id="aurora-check" viewBox="0 0 24 24"><path d="m9.5 16.5-4-4L7 11l2.5 2.5L17 6l1.5 1.5z"/></symbol>',
+      '</svg>'
     ].join("");
-
-    document.body.insertBefore(wrapper, document.body.firstChild);
+    document.body.insertBefore(sprite, document.body.firstChild);
   }
 
   function iconElement(id) {
@@ -81,112 +75,134 @@
     svg.setAttribute("aria-hidden", "true");
     svg.setAttribute("focusable", "false");
     var use = document.createElementNS("http://www.w3.org/2000/svg", "use");
-    use.setAttributeNS("http://www.w3.org/1999/xlink", "href", "#ns-" + id);
-    use.setAttribute("href", "#ns-" + id);
+    use.setAttributeNS("http://www.w3.org/1999/xlink", "href", "#aurora-" + id);
+    use.setAttribute("href", "#aurora-" + id);
     svg.appendChild(use);
     return svg;
   }
 
-  function ensureIcon(target, id) {
-    if (!target) {
-      return;
+  function textContentWithoutChrome(node) {
+    if (!node) {
+      return "";
     }
-    var link = target.matches("a, button") ? target : target.querySelector("a, button");
-    if (!link) {
-      return;
-    }
-
-    if (link.dataset.nsModernIcon === id) {
-      return;
-    }
-    link.dataset.nsModernIcon = id;
-
-    var oldIcons = link.querySelectorAll("i, span[class*='icon'], span[class*='fa-'], svg.ns-icon");
-    Array.prototype.forEach.call(oldIcons, function (node) {
-      node.parentNode && node.parentNode.removeChild(node);
+    var clone = node.cloneNode(true);
+    Array.prototype.slice.call(clone.querySelectorAll(".nav-bg-image, svg, img, use, picture, .ns-icon")).forEach(function (child) {
+      child.remove();
     });
-
-    var svg = iconElement(id);
-    link.insertBefore(svg, link.firstChild);
-
-    var text = (link.textContent || "").trim();
-    if (!text) {
-      var readable = id.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/-/g, " ");
-      text = readable.charAt(0).toUpperCase() + readable.slice(1);
-    }
-    if (!link.getAttribute("aria-label")) {
-      link.setAttribute("aria-label", text);
-    }
-    if (!link.getAttribute("title")) {
-      link.setAttribute("title", text);
-    }
+    return (clone.textContent || "").replace(/\s+/g, " ").trim();
   }
 
-  function enhanceNavigation() {
-    var topBar = document.querySelector(".navigation-subbar") ||
+  function applyIconToTarget(target, id) {
+    if (!target || !id) {
+      return null;
+    }
+    var link = target.matches && target.matches("a, button") ? target : target.querySelector && target.querySelector("a, button");
+    if (!link) {
+      return null;
+    }
+    if (link.dataset.auroraIcon === id) {
+      Array.prototype.slice.call(link.querySelectorAll("div.nav-bg-image, span.nav-bg-image")).forEach(function (legacy) {
+        legacy.remove();
+      });
+      return link;
+    }
+    link.dataset.auroraIcon = id;
+    Array.prototype.slice.call(link.querySelectorAll("i, span[class*='icon'], span.nav-bg-image, div.nav-bg-image, svg.ns-icon"))
+      .forEach(function (node) {
+        node.remove();
+      });
+    link.insertBefore(iconElement(id), link.firstChild);
+    var label = textContentWithoutChrome(link);
+    if (label && !link.getAttribute("aria-label")) {
+      link.setAttribute("aria-label", label);
+    }
+    if (!link.getAttribute("title")) {
+      link.setAttribute("title", link.getAttribute("aria-label") || id);
+    }
+    Array.prototype.slice.call((target.matches && target.matches("li, div")) ? target.querySelectorAll(".nav-bg-image") : [])
+      .forEach(function (legacyIcon) {
+        legacyIcon.remove();
+      });
+    return link;
+  }
+
+  function decorateHeader() {
+    var bar = document.querySelector(".navigation-subbar") ||
       document.querySelector("#ns-topbar") ||
       document.querySelector(".header-bar") ||
       document.querySelector(".navbar");
 
-    if (!topBar) {
-      return;
+    if (!bar) {
+      return null;
     }
 
-    topBar.classList.add("is-modernized");
-
-    if (!topBar.dataset.nsModernScrollListener) {
-      var onScroll = throttle(function () {
-        var scrolled = window.scrollY > 12;
-        topBar.classList.toggle("is-scrolled", scrolled);
-      }, 120);
-      window.addEventListener("scroll", onScroll, { passive: true });
-      topBar.dataset.nsModernScrollListener = "true";
-      onScroll();
-    }
-
-    if (!topBar.querySelector(".ns-modern-topbar-brand")) {
+    if (!bar.querySelector(".ns-brand")) {
       var brand = document.createElement("div");
-      brand.className = "ns-modern-topbar-brand";
+      brand.className = "ns-brand";
       var picture = document.createElement("picture");
-      var darkSource = document.createElement("source");
-      darkSource.media = "(prefers-color-scheme: dark)";
-      darkSource.srcset = LOGO_DARK_URL;
-      var lightImg = document.createElement("img");
-      lightImg.className = "ns-modern-logo";
-      lightImg.src = LOGO_LIGHT_URL;
-      lightImg.alt = "NetSapiens Manager";
-      lightImg.decoding = "async";
-      lightImg.loading = "lazy";
-      picture.appendChild(darkSource);
-      picture.appendChild(lightImg);
+      var source = document.createElement("source");
+      source.media = "(prefers-color-scheme: dark)";
+      source.srcset = LOGO_DARK;
+      picture.appendChild(source);
+      var img = document.createElement("img");
+      img.className = "ns-brand__logo";
+      img.src = LOGO_LIGHT;
+      img.alt = "NetSapiens Portal";
+      img.decoding = "async";
+      img.loading = "lazy";
+      picture.appendChild(img);
       brand.appendChild(picture);
-      topBar.insertBefore(brand, topBar.firstChild);
+      bar.insertBefore(brand, bar.firstChild);
     }
 
-    if (!topBar.querySelector(".ns-modern-header-actions")) {
+    if (!bar.querySelector(".ns-header-actions")) {
       var actions = document.createElement("div");
-      actions.className = "ns-modern-header-actions";
-      topBar.appendChild(actions);
+      actions.className = "ns-header-actions";
+      bar.appendChild(actions);
     }
 
-    var actionsHost = topBar.querySelector(".ns-modern-header-actions");
-    if (actionsHost && !actionsHost.querySelector("[data-ns-modern-billing]")) {
-      var billingBtn = document.createElement("button");
-      billingBtn.type = "button";
-      billingBtn.className = "ns-modern-header-button";
-      billingBtn.setAttribute("data-ns-modern-billing", "trigger");
-      billingBtn.setAttribute("aria-haspopup", "dialog");
-      billingBtn.setAttribute("aria-expanded", "false");
-      billingBtn.innerHTML = '<span>Billing</span>';
-      actionsHost.appendChild(billingBtn);
+    var host = bar.querySelector(".ns-header-actions");
+
+    if (host && !host.querySelector(".ns-header-time")) {
+      var clock = document.createElement("span");
+      clock.className = "ns-header-time";
+      clock.setAttribute("aria-live", "polite");
+      clock.textContent = formatClock(new Date());
+      host.appendChild(clock);
+      setInterval(function () {
+        clock.textContent = formatClock(new Date());
+      }, 60000);
     }
+
+    if (host && !host.querySelector("[data-aurora-billing]")) {
+      var billing = document.createElement("button");
+      billing.type = "button";
+      billing.className = "ns-header-button";
+      billing.dataset.auroraBilling = "trigger";
+      billing.setAttribute("aria-haspopup", "dialog");
+      billing.setAttribute("aria-expanded", "false");
+      billing.appendChild(iconElement("analytics"));
+      billing.appendChild(document.createTextNode("Billing"));
+      host.appendChild(billing);
+    }
+
+    window.addEventListener("scroll", throttle(function () {
+      var scrolled = window.scrollY > 12;
+      bar.classList.toggle("is-scrolled", scrolled);
+    }, 120), { passive: true });
+
+    return bar;
   }
 
-  function applyIcons() {
-    var map = {
+  function formatClock(date) {
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  function applyNavigationIcons() {
+    var iconMap = {
       "#menu-home": "home",
-      "#menu-callcenter": "callcenter",
       "#menu-users": "users",
+      "#menu-callcenter": "callcenter",
       "#menu-conferences": "conferences",
       "#menu-autoattendants": "autoattendants",
       "#menu-queues": "queues",
@@ -199,17 +215,241 @@
       "#menu-callhistory": "callhistory"
     };
 
-    Object.keys(map).forEach(function (selector) {
-      var symbol = map[selector];
-      var node = document.querySelector(selector);
-      if (!node) {
+    Object.keys(iconMap).forEach(function (selector) {
+      var target = document.querySelector(selector);
+      if (!target) {
         return;
       }
-      ensureIcon(node, symbol);
+      applyIconToTarget(target, iconMap[selector]);
     });
   }
 
-  function ensureToastStack() {
+  function hydrateLegacyNavigation() {
+    var labelMap = {
+      "home": "home",
+      "dashboard": "home",
+      "call center": "callcenter",
+      "call queues": "queues",
+      "queues": "queues",
+      "users": "users",
+      "conferences": "conferences",
+      "conference": "conferences",
+      "auto attendants": "autoattendants",
+      "auto attendant": "autoattendants",
+      "time frames": "timeframes",
+      "music on hold": "moh",
+      "route profiles": "routes",
+      "routes": "routes",
+      "inventory": "inventory",
+      "smart routing": "smartrouting",
+      "analytics": "analytics",
+      "call history": "callhistory"
+    };
+
+    var legacyIcons = document.querySelectorAll(".nav-bg-image");
+    if (!legacyIcons.length) {
+      return;
+    }
+
+    Array.prototype.forEach.call(legacyIcons, function (node) {
+      var host = node.closest("a, button, li, .nav-item") || node.parentElement;
+      if (!host) {
+        return;
+      }
+      var link = host.matches && host.matches("a, button") ? host : host.querySelector && host.querySelector("a, button");
+      var textSource = link || host;
+      var label = textContentWithoutChrome(textSource).toLowerCase();
+      var iconId = labelMap[label];
+      if (!iconId) {
+        Object.keys(labelMap).some(function (key) {
+          if (label.indexOf(key) !== -1) {
+            iconId = labelMap[key];
+            return true;
+          }
+          return false;
+        });
+      }
+      if (!iconId) {
+        return;
+      }
+      applyIconToTarget(host, iconId);
+      if (node.parentNode) {
+        node.remove();
+      }
+    });
+  }
+
+  function findContainer() {
+    return document.querySelector(".content-wrapper") ||
+      document.querySelector(".page-content") ||
+      document.querySelector("main") ||
+      document.querySelector("#content") ||
+      document.querySelector(".container-fluid") ||
+      document.body;
+  }
+
+  function injectHero(container) {
+    if (!container || container.querySelector(".ns-hero")) {
+      return;
+    }
+    var hero = document.createElement("section");
+    hero.className = "ns-hero";
+    hero.innerHTML = [
+      '<div class="ns-hero__eyebrow">Control Center</div>',
+      '<h1 class="ns-hero__title">Craft premium calling experiences for every customer.</h1>',
+      '<p class="ns-hero__subtitle">Monitor live calls, update routing, and jump into action faster with an immersive Aurora workspace designed for service providers.</p>',
+      '<div class="ns-hero__meta" aria-live="polite">' + greeting() + '</div>'
+    ].join("");
+    container.insertBefore(hero, container.firstChild);
+  }
+
+  function greeting() {
+    var hour = new Date().getHours();
+    if (hour < 12) {
+      return "Good morning";
+    }
+    if (hour < 18) {
+      return "Good afternoon";
+    }
+    return "Good evening";
+  }
+
+  function ensureQuickActions(container) {
+    if (!container || container.querySelector(".ns-quick-actions")) {
+      return;
+    }
+    var section = document.createElement("section");
+    section.className = "ns-surface";
+    section.setAttribute("aria-label", "Quick actions");
+    var body = document.createElement("div");
+    body.className = "panel-body";
+
+    var header = document.createElement("header");
+    header.className = "panel-heading";
+    header.innerHTML = '<div><div class="ns-badge">Quick launch</div><h2>Quick actions</h2></div>' +
+      '<button type="button" class="ns-header-button" data-aurora-refresh>Refresh view</button>';
+    section.appendChild(header);
+
+    var wrap = document.createElement("div");
+    wrap.className = "ns-quick-actions";
+
+    var actions = [
+      { label: "Provision user", icon: "plus", message: "Pretend we opened the user provisioning wizard." },
+      { label: "Create call queue", icon: "queues", message: "Queue builder launched in a separate view (imagine)." },
+      { label: "Schedule meeting", icon: "conferences", message: "Meeting template created with defaults." },
+      { label: "Launch analytics", icon: "analytics", message: "Analytics dashboard would open in a new tab." }
+    ];
+
+    actions.forEach(function (action) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "ns-quick-actions__btn";
+      btn.setAttribute("data-action", action.label);
+      btn.appendChild(iconElement(action.icon));
+      btn.appendChild(document.createTextNode(action.label));
+      btn.addEventListener("click", function () {
+        showToast(action.message);
+      });
+      wrap.appendChild(btn);
+    });
+
+    body.appendChild(wrap);
+    section.appendChild(body);
+    container.insertBefore(section, container.querySelector(".ns-hero") ? container.children[1] : container.firstChild);
+
+    var refresh = section.querySelector("[data-aurora-refresh]");
+    if (refresh) {
+      refresh.addEventListener("click", function () {
+        showToast("Dashboard refreshed — data is simulated.");
+      });
+    }
+  }
+
+  function ensureMetrics(container) {
+    if (!container || container.querySelector(".ns-metric-grid")) {
+      return;
+    }
+    var metrics = document.createElement("section");
+    metrics.className = "ns-surface";
+    metrics.innerHTML = [
+      '<header class="panel-heading"><div><div class="ns-badge">Health</div><h2>Service snapshot</h2></div></header>',
+      '<div class="panel-body">',
+      '<div class="ns-metric-grid">',
+      metricCard("Active calls", "128", "+12% vs yesterday"),
+      metricCard("Average wait", "00:43", "Down 6% this hour", "warning"),
+      metricCard("SLA compliance", "99.2%", "On track", "success"),
+      metricCard("Tickets open", "18", "5 require follow-up", "danger"),
+      '</div></div>'
+    ].join("");
+    container.insertBefore(metrics, container.querySelector(".ns-hero") ? container.children[2] : container.firstChild);
+  }
+
+  function metricCard(label, value, trend, tone) {
+    var className = "ns-metric";
+    if (tone) {
+      className += " ns-metric--" + tone;
+    }
+    return [
+      '<article class="' + className + '" tabindex="0">',
+      '<div class="ns-metric__label">' + label + '</div>',
+      '<div class="ns-metric__value">' + value + '</div>',
+      '<div class="ns-metric__trend">' + trend + '</div>',
+      '</article>'
+    ].join("");
+  }
+
+  function ensureSearch(container) {
+    if (!container || container.querySelector(".ns-search")) {
+      return;
+    }
+    var section = document.createElement("section");
+    section.className = "ns-search";
+    section.innerHTML = '<label for="aurora-search">Global search</label>' +
+      '<input type="search" id="aurora-search" placeholder="Search cards, calls, and settings" autocomplete="off" aria-describedby="aurora-search-help">' +
+      '<small id="aurora-search-help" class="ns-text-subtle">Filtering is instant and client-side.</small>';
+    container.insertBefore(section, container.querySelector(".ns-surface") || container.querySelector(".panel"));
+
+    var empty = document.createElement("div");
+    empty.className = "ns-empty-state";
+    empty.textContent = "No matching modules. Try adjusting your keywords.";
+    empty.hidden = true;
+    container.appendChild(empty);
+
+    var cards = [];
+
+    function catalog() {
+      cards = [];
+      Array.prototype.forEach.call(container.querySelectorAll(".panel, .card, .ns-surface, .dashboard-card, .tile, .portlet"), function (panel) {
+        var text = (panel.textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+        cards.push({ node: panel, text: text, display: panel.style.display || "" });
+      });
+    }
+
+    function applyFilter(value) {
+      var query = (value || "").trim().toLowerCase();
+      if (!cards.length) {
+        catalog();
+      }
+      var visible = 0;
+      cards.forEach(function (entry) {
+        var match = !query || entry.text.indexOf(query) !== -1;
+        entry.node.style.display = match ? entry.display : "none";
+        entry.node.setAttribute("aria-hidden", match ? "false" : "true");
+        if (match) {
+          visible += 1;
+        }
+      });
+      empty.hidden = visible !== 0;
+    }
+
+    catalog();
+
+    section.querySelector("input").addEventListener("input", function (event) {
+      applyFilter(event.target.value);
+    });
+  }
+
+  function showToast(message) {
     var stack = document.querySelector(".ns-toast-stack");
     if (!stack) {
       stack = document.createElement("div");
@@ -218,192 +458,122 @@
       stack.setAttribute("aria-atomic", "false");
       document.body.appendChild(stack);
     }
-    return stack;
-  }
-
-  function logEvent(entry) {
-    try {
-      var record = { timestamp: Date.now() };
-      if (entry && typeof entry === "object") {
-        for (var key in entry) {
-          if (Object.prototype.hasOwnProperty.call(entry, key)) {
-            record[key] = entry[key];
-          }
-        }
-      }
-      ns.log.push(record);
-      if (ns.log.length > 50) {
-        ns.log.splice(0, ns.log.length - 50);
-      }
-    } catch (err) {
-      if (window.console && window.console.warn) {
-        window.console.warn("__nsModern log error", err);
-      }
-    }
-  }
-
-  function showToast(message) {
-    var stack = ensureToastStack();
     var toast = document.createElement("div");
     toast.className = "ns-toast";
-    toast.setAttribute("role", "status");
     toast.dataset.state = "enter";
-    toast.textContent = message;
+    toast.setAttribute("role", "status");
+    var icon = document.createElement("span");
+    icon.className = "ns-toast__icon";
+    icon.appendChild(iconElement("check"));
+    var text = document.createElement("div");
+    text.className = "ns-toast__message";
+    text.textContent = message;
+    var close = document.createElement("button");
+    close.type = "button";
+    close.className = "ns-toast__close";
+    close.setAttribute("aria-label", "Dismiss notification");
+    close.textContent = "×";
+    close.addEventListener("click", function () {
+      removeToast(toast);
+    });
+    toast.appendChild(icon);
+    toast.appendChild(text);
+    toast.appendChild(close);
     stack.appendChild(toast);
 
-    if (REDUCED_MOTION) {
-      toast.dataset.state = "";
-    }
+    var reduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var duration = reduced ? 2200 : TOAST_DURATION;
 
-    var duration = REDUCED_MOTION ? 0 : TOAST_DURATION;
-    if (duration) {
-      setTimeout(function () {
-        toast.dataset.state = "leave";
-      }, duration - 400);
-      setTimeout(function () {
-        if (toast.parentNode) {
-          toast.parentNode.removeChild(toast);
-        }
-      }, duration);
-    } else {
-      setTimeout(function () {
-        if (toast.parentNode) {
-          toast.parentNode.removeChild(toast);
-        }
-      }, 1200);
-    }
+    var timer = setTimeout(function () {
+      removeToast(toast);
+    }, duration);
+
+    toast.addEventListener("mouseenter", function () {
+      clearTimeout(timer);
+    });
+    toast.addEventListener("mouseleave", function () {
+      timer = setTimeout(function () {
+        removeToast(toast);
+      }, duration / 2);
+    });
   }
 
-  function enhanceCards() {
-    var selectors = [".panel", ".box", ".card", ".tile", ".dashboard-card", ".portlet"];
-    var cards = [];
-    selectors.forEach(function (selector) {
-      var found = document.querySelectorAll(selector);
-      Array.prototype.forEach.call(found, function (card) {
-        var text = (card.textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
-        card.dataset.nsModernSearch = text;
-        if (card.dataset && card.dataset.nsModernCard === "true") {
-          if (!card.dataset.nsModernDisplay) {
-            card.dataset.nsModernDisplay = card.style.display || "";
+  function removeToast(toast) {
+    if (!toast || !toast.parentNode) {
+      return;
+    }
+    toast.dataset.state = "leave";
+    setTimeout(function () {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 180);
+  }
+
+  function modernizeTables() {
+    var tables = document.querySelectorAll("#calls_table, #calls_table_meetings");
+    if (!tables.length) {
+      return;
+    }
+    tables.forEach(function (table) {
+      var headers = [];
+      var thead = table.querySelector("thead");
+      if (thead) {
+        headers = Array.prototype.map.call(thead.querySelectorAll("th, td"), function (cell) {
+          return (cell.textContent || "").trim();
+        });
+      }
+      table.classList.add("ns-call-table");
+      Array.prototype.forEach.call(table.querySelectorAll("tbody tr"), function (row) {
+        if (!row.getAttribute("tabindex")) {
+          row.setAttribute("tabindex", "0");
+        }
+        row.classList.add("ns-call-card");
+        var cells = row.querySelectorAll("td");
+        Array.prototype.forEach.call(cells, function (cell, index) {
+          if (!cell.hasAttribute("data-label") && headers[index]) {
+            cell.setAttribute("data-label", headers[index]);
           }
-          cards.push(card);
-          return;
+          var value = (cell.textContent || "").trim();
+          if (index === 2 && value) {
+            ensureBadge(cell, value);
+          }
+        });
+        if (!row.getAttribute("aria-label")) {
+          var summary = cells[0] ? (cells[0].textContent || "").trim() : "Row";
+          row.setAttribute("aria-label", summary);
         }
-        card.dataset.nsModernCard = "true";
-        card.classList.add("ns-modern-card");
-        if (!card.dataset.nsModernDisplay) {
-          card.dataset.nsModernDisplay = card.style.display || "";
-        }
-        cards.push(card);
       });
+
+      if (!table.dataset.auroraObserver) {
+        var observer = new MutationObserver(function () {
+          modernizeTables();
+        });
+        observer.observe(table, { childList: true, subtree: true });
+        table.dataset.auroraObserver = "true";
+      }
     });
-    return cards;
   }
 
-  function ensureEmptyState(container) {
-    var empty = container.querySelector(".ns-empty-state");
-    if (!empty) {
-      empty = document.createElement("div");
-      empty.className = "ns-empty-state";
-      empty.textContent = "No matching results. Try a different search.";
-      empty.setAttribute("aria-live", "polite");
-      empty.hidden = true;
-      container.appendChild(empty);
-    }
-    return empty;
-  }
-
-  function setupSearch(container) {
-    if (!container || container.querySelector(".ns-global-search")) {
+  function ensureBadge(cell, value) {
+    if (cell.querySelector(".ns-call-badge")) {
       return;
     }
-
-    var cards = enhanceCards();
-    var wrapper = document.createElement("div");
-    wrapper.className = "ns-global-search";
-
-    var label = document.createElement("label");
-    label.setAttribute("for", "ns-global-search-input");
-    label.textContent = "Global search";
-
-    var input = document.createElement("input");
-    input.type = "search";
-    input.id = "ns-global-search-input";
-    input.placeholder = "Search cards and tables";
-    input.setAttribute("autocomplete", "off");
-    input.setAttribute("aria-describedby", "ns-global-search-help");
-
-    var helper = document.createElement("small");
-    helper.id = "ns-global-search-help";
-    helper.className = "ns-muted";
-    helper.textContent = "Type to filter visible cards instantly.";
-
-    wrapper.appendChild(label);
-    wrapper.appendChild(input);
-    wrapper.appendChild(helper);
-
-    container.insertBefore(wrapper, container.firstChild);
-
-    var emptyState = ensureEmptyState(container);
-
-    function updateMatches(value) {
-      var matches = 0;
-      var query = value.trim().toLowerCase();
-      cards = enhanceCards();
-      cards.forEach(function (card) {
-        if (!card.dataset.nsModernDisplay) {
-          card.dataset.nsModernDisplay = card.style.display || "";
-        }
-        var haystack = card.dataset.nsModernSearch || (card.textContent || "").toLowerCase();
-        var visible = !query || haystack.indexOf(query) !== -1;
-        card.style.display = visible ? card.dataset.nsModernDisplay : "none";
-        card.setAttribute("aria-hidden", visible ? "false" : "true");
-        if (visible) {
-          matches += 1;
-        }
-      });
-      emptyState.hidden = matches !== 0;
+    var tone = value.toLowerCase();
+    var badge = document.createElement("span");
+    badge.className = "ns-call-badge";
+    if (tone.indexOf("park") !== -1 || tone.indexOf("hold") !== -1) {
+      badge.style.background = "rgba(244, 176, 0, 0.18)";
+      badge.style.color = "#f4b000";
+      badge.textContent = "On Hold";
+    } else if (tone.indexOf("voicemail") !== -1) {
+      badge.style.background = "rgba(249, 104, 108, 0.18)";
+      badge.style.color = "#f9686c";
+      badge.textContent = "Voicemail";
+    } else {
+      badge.textContent = "Live";
     }
-
-    input.addEventListener("input", function (event) {
-      updateMatches(event.target.value || "");
-    });
-
-    updateMatches("");
-  }
-
-  function setupQuickActions(container) {
-    if (!container || container.querySelector(".ns-quick-actions")) {
-      return;
-    }
-
-    var actions = [
-      { label: "Add User", icon: "users" },
-      { label: "Create Queue", icon: "queues" },
-      { label: "Open Ticket", icon: "callcenter" }
-    ];
-
-    var wrap = document.createElement("div");
-    wrap.className = "ns-quick-actions";
-
-    actions.forEach(function (action) {
-      var btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "ns-quick-actions__btn";
-      btn.setAttribute("data-action", action.label);
-      btn.appendChild(iconElement(action.icon));
-      var span = document.createElement("span");
-      span.textContent = action.label;
-      btn.appendChild(span);
-      btn.addEventListener("click", function () {
-        var message = "Pretend we " + action.label.toLowerCase() + ".";
-        showToast(message);
-        logEvent({ type: "quick-action", action: action.label });
-      });
-      wrap.appendChild(btn);
-    });
-
-    container.insertBefore(wrap, container.firstChild);
+    cell.insertBefore(badge, cell.firstChild);
   }
 
   function ensureDrawer() {
@@ -421,43 +591,95 @@
       drawer.className = "ns-drawer";
       drawer.setAttribute("role", "dialog");
       drawer.setAttribute("aria-modal", "true");
-      drawer.setAttribute("aria-labelledby", "ns-drawer-title");
-      drawer.setAttribute("tabindex", "-1");
-      drawer.setAttribute("aria-hidden", "true");
-
-      var header = document.createElement("div");
-      header.className = "ns-drawer__header";
-
-      var title = document.createElement("h2");
-      title.className = "ns-drawer__title";
-      title.id = "ns-drawer-title";
-      title.textContent = "Billing Overview";
-
-      var close = document.createElement("button");
-      close.type = "button";
-      close.className = "ns-drawer__close";
-      close.setAttribute("aria-label", "Close billing drawer");
-      close.innerHTML = "&times;";
-
-      header.appendChild(title);
-      header.appendChild(close);
-
-      var body = document.createElement("div");
-      body.className = "ns-drawer__body";
-      body.innerHTML = "<p class=\"ns-muted\">This is a placeholder for billing metrics, upcoming invoices, and payment methods. Integrate with your billing provider to surface real data.</p><ul class=\"ns-stack\"><li><strong>Current balance:</strong> $0.00 (demo)</li><li><strong>Next invoice:</strong> May 31</li><li><strong>Last payment:</strong> Apr 30 via ACH</li></ul>";
-
-      drawer.appendChild(header);
-      drawer.appendChild(body);
+      drawer.setAttribute("aria-labelledby", "aurora-drawer-title");
+      drawer.innerHTML = [
+        '<div class="ns-drawer__header">',
+        '<h2 class="ns-drawer__title" id="aurora-drawer-title">Billing overview</h2>',
+        '<button type="button" class="ns-drawer__close" aria-label="Close billing panel">×</button>',
+        '</div>',
+        '<div class="ns-drawer__body">',
+        '<p class="ns-text-subtle">Preview billing summaries, upcoming renewals, and credit usage. Integrate your provider API to populate these values in production.</p>',
+        '<ul class="ns-stack">',
+        '<li><strong>Current balance:</strong> $0.00 (demo)</li>',
+        '<li><strong>Next invoice:</strong> June 30</li>',
+        '<li><strong>Auto-pay:</strong> Enabled for ACH ending in ••28</li>',
+        '<li><strong>Recent credit packs:</strong> None</li>',
+        '</ul>',
+        '</div>'
+      ].join("");
       document.body.appendChild(drawer);
     }
 
-    return { overlay: overlay, drawer: drawer };
+    var trigger = document.querySelector('[data-aurora-billing="trigger"]');
+    if (!trigger) {
+      return;
+    }
+
+    var closeBtn = drawer.querySelector(".ns-drawer__close");
+    var state = { open: false, lastFocus: null };
+
+    function open() {
+      if (state.open) {
+        return;
+      }
+      state.open = true;
+      state.lastFocus = document.activeElement;
+      overlay.classList.add("is-visible");
+      overlay.setAttribute("aria-hidden", "false");
+      drawer.classList.add("is-open");
+      drawer.setAttribute("aria-hidden", "false");
+      document.body.classList.add("ns-drawer-open");
+      trigger.setAttribute("aria-expanded", "true");
+      setTimeout(function () {
+        var focusable = drawer.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        (focusable || drawer).focus();
+      }, 20);
+    }
+
+    function close() {
+      if (!state.open) {
+        return;
+      }
+      state.open = false;
+      overlay.classList.remove("is-visible");
+      overlay.setAttribute("aria-hidden", "true");
+      drawer.classList.remove("is-open");
+      drawer.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("ns-drawer-open");
+      trigger.setAttribute("aria-expanded", "false");
+      if (state.lastFocus && typeof state.lastFocus.focus === "function") {
+        state.lastFocus.focus();
+      }
+    }
+
+    trigger.addEventListener("click", function () {
+      state.open ? close() : open();
+    });
+
+    overlay.addEventListener("click", function (event) {
+      if (event.target === overlay) {
+        close();
+      }
+    });
+
+    [drawer, document].forEach(function (node) {
+      node.addEventListener("keydown", function (event) {
+        if (event.key === "Escape" && state.open) {
+          event.preventDefault();
+          close();
+        } else if (event.key === "Tab" && state.open) {
+          trapFocus(drawer, event);
+        }
+      });
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener("click", close);
+    }
   }
 
   function trapFocus(container, event) {
-    var focusable = container.querySelectorAll(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
-    );
+    var focusable = container.querySelectorAll('a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])');
     if (!focusable.length) {
       event.preventDefault();
       container.focus();
@@ -474,125 +696,44 @@
     }
   }
 
-  function setupBillingDrawer() {
-    var parts = ensureDrawer();
-    var overlay = parts.overlay;
-    var drawer = parts.drawer;
-    var trigger = document.querySelector('[data-ns-modern-billing="trigger"]');
-    if (!drawer || !overlay || !trigger) {
+  function setupGlobalObservers() {
+    if (window.__auroraNavObserver) {
       return;
     }
-
-    var state = { open: false, lastFocus: null };
-    ns.drawerState = state;
-
-    function openDrawer() {
-      if (state.open) {
-        return;
-      }
-      state.open = true;
-      state.lastFocus = document.activeElement;
-      overlay.classList.add("is-visible");
-      overlay.setAttribute("aria-hidden", "false");
-      drawer.classList.add("is-open");
-      drawer.setAttribute("aria-hidden", "false");
-      document.body.classList.add("ns-modern-drawer-open");
-      trigger.setAttribute("aria-expanded", "true");
-      logEvent({ type: "drawer", action: "open" });
-      setTimeout(function () {
-        var focusable = drawer.querySelector(
-          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        (focusable || drawer).focus();
-      }, 20);
-    }
-
-    function closeDrawer() {
-      if (!state.open) {
-        return;
-      }
-      state.open = false;
-      overlay.classList.remove("is-visible");
-      overlay.setAttribute("aria-hidden", "true");
-      drawer.classList.remove("is-open");
-      drawer.setAttribute("aria-hidden", "true");
-      document.body.classList.remove("ns-modern-drawer-open");
-      trigger.setAttribute("aria-expanded", "false");
-      logEvent({ type: "drawer", action: "close" });
-      if (state.lastFocus && typeof state.lastFocus.focus === "function") {
-        state.lastFocus.focus();
-      }
-    }
-    state.close = closeDrawer;
-    state.openDrawer = openDrawer;
-
-    if (!trigger.dataset.nsModernDrawerBound) {
-      trigger.addEventListener("click", function () {
-        if (state.open) {
-          closeDrawer();
-        } else {
-          openDrawer();
-        }
-      });
-      trigger.dataset.nsModernDrawerBound = "true";
-    }
-
-    if (!overlay.dataset.nsModernDrawerBound) {
-      overlay.addEventListener("click", function (event) {
-        if (event.target === overlay) {
-          closeDrawer();
-        }
-      });
-      overlay.dataset.nsModernDrawerBound = "true";
-    }
-
-    if (!drawer.dataset.nsModernDrawerBound) {
-      drawer.addEventListener("keydown", function (event) {
-        if (event.key === "Escape") {
-          event.preventDefault();
-          closeDrawer();
-        } else if (event.key === "Tab") {
-          trapFocus(drawer, event);
-        }
-      });
-      var closeBtn = drawer.querySelector(".ns-drawer__close");
-      if (closeBtn && !closeBtn.dataset.nsModernDrawerBound) {
-        closeBtn.addEventListener("click", function () {
-          closeDrawer();
+    window.__auroraNavObserver = new MutationObserver(function (records) {
+      var shouldUpdate = records.some(function (record) {
+        return Array.prototype.some.call(record.addedNodes || [], function (node) {
+          return node.nodeType === 1 && (
+            (node.matches && node.matches("#menu-home, #menu-users, #menu-callcenter, #menu-conferences")) ||
+            (node.matches && node.matches(".nav-bg-image")) ||
+            (node.querySelector && node.querySelector("#menu-home, #menu-users, #menu-callcenter, #menu-conferences, .nav-bg-image"))
+          );
         });
-        closeBtn.dataset.nsModernDrawerBound = "true";
+      });
+      if (shouldUpdate) {
+        applyNavigationIcons();
+        hydrateLegacyNavigation();
       }
-      drawer.dataset.nsModernDrawerBound = "true";
-    }
-
-    if (!ns._drawerKeyListener) {
-      ns._drawerKeyListener = function (event) {
-        if (event.key === "Escape" && ns.drawerState && ns.drawerState.open) {
-          ns.drawerState.close();
-        }
-      };
-      document.addEventListener("keydown", ns._drawerKeyListener);
-    }
+    });
+    window.__auroraNavObserver.observe(document.body, { childList: true, subtree: true });
   }
 
   onReady(function () {
     if (!document.body) {
       return;
     }
-
     ensureSprite();
-    enhanceNavigation();
-    applyIcons();
-
-    var content = document.querySelector(".content-wrapper") ||
-      document.querySelector(".page-content") ||
-      document.querySelector("main") ||
-      document.querySelector("#content") ||
-      document.querySelector(".container-fluid") ||
-      document.body;
-
-    setupQuickActions(content);
-    setupSearch(content);
-    setupBillingDrawer();
+    decorateHeader();
+    applyNavigationIcons();
+    hydrateLegacyNavigation();
+    setupGlobalObservers();
+    var container = findContainer();
+    injectHero(container);
+    ensureQuickActions(container);
+    ensureMetrics(container);
+    ensureSearch(container);
+    modernizeTables();
+    ensureDrawer();
   });
+
 }(window, document));


### PR DESCRIPTION
## Summary
- switch the portal design tokens, gradients, and hero shell to an ember-inspired light/dark palette
- restyle navigation, metrics, and active call cards to match the warm theme and improve hover/stripe treatments
- expand the nav icon replacement script to handle legacy `.nav-bg-image` menus via text-matched SVG swaps

## Testing
- Not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_b_68de80fc083c832db0f4f6a7e42e6c41